### PR TITLE
[Assistants Settings] Small fixes in darkmode

### DIFF
--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -120,7 +120,7 @@
 		<h2 class="text-xl font-semibold dark:text-gray-300">Create new assistant</h2>
 		<p class="mb-6 text-sm text-gray-500 dark:text-gray-400">
 			Create and share your own AI Assistant. All assistants are <span
-				class="rounded-full border px-2 py-0.5 leading-none">public</span
+				class="rounded-full border px-2 py-0.5 leading-none dark:border-gray-600">public</span
 			>
 		</p>
 	{/if}

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -177,7 +177,7 @@
 					<div class="mb-1 flex w-max flex-row gap-4">
 						<label
 							for="avatar"
-							class="btn flex h-8 rounded-lg border bg-white px-3 py-1 text-gray-500 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400 dark:hover:bg-gray-700"
+							class="btn flex h-8 rounded-lg border bg-white px-3 py-1 text-gray-500 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-700"
 						>
 							<CarbonUpload class="mr-2 text-xs " /> Upload
 						</label>

--- a/src/routes/settings/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/assistants/[assistantId]/+page.svelte
@@ -76,8 +76,8 @@
 			<div class="flex items-center gap-4 whitespace-nowrap text-sm">
 				<button
 					class="{isActive
-						? 'bg-gray-100 text-gray-800 dark:bg-gray-300 dark:text-gray-900'
-						: 'bg-black text-white dark:bg-gray-800 dark:text-gray-300'} my-2 flex w-fit items-center rounded-full px-3 py-1 text-base"
+						? 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300'
+						: 'bg-black text-white dark:bg-gray-300 dark:text-gray-900'} my-2 flex w-fit items-center rounded-full px-3 py-1 text-base"
 					disabled={isActive}
 					name="Activate model"
 					on:click|stopPropagation={() => {

--- a/src/routes/settings/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/assistants/[assistantId]/+page.svelte
@@ -55,7 +55,7 @@
 					{assistant?.name}
 				</h1>
 				<span
-					class="rounded-full border px-2 py-0.5 text-sm leading-none text-gray-500 dark:text-gray-400"
+					class="rounded-full border px-2 py-0.5 text-sm leading-none text-gray-500 dark:border-gray-600 dark:text-gray-400"
 					>public</span
 				>
 			</div>


### PR DESCRIPTION
Made two small fixes.

1. Dark class border was missing for `public` label
![image](https://github.com/KartikGS/chat-ui/assets/11827707/509529b7-2b75-42c6-904a-36ca44d86be1)
2. Upload avatar btn fix 
![image](https://github.com/KartikGS/chat-ui/assets/11827707/509529b7-2b75-42c6-904a-36ca44d86be1)
3. Switch classes between activa/activate in assistants https://github.com/KartikGS/chat-ui/pull/1/commits/ed86754e2206b8fc3fb7e12e9c3b180c3a99f71f

cc: @KartikGS 
